### PR TITLE
Fixed goto button

### DIFF
--- a/Halo/TagObjects/vehi.cs
+++ b/Halo/TagObjects/vehi.cs
@@ -790,5 +790,212 @@ namespace Assembly69.Halo.TagObjects {
             { 0xBDC, new c{ T="TagRef"}}, // EFFE
             { 0xBF5, new c{ T="TagRef"}}, // EFFE
         };
+
+        public static Dictionary<long, c> sddtTag = new Dictionary<long, c>
+        {
+            { 0, new c{ T="Pointer"}},
+            { 8, new c{ T="4Byte"}}, // datnum
+            { 12, new c{ T="4Byte"}}, // tagID
+
+            { 0x40, new c{ T="4Byte"}},
+
+            { 0x44, new c{ T="Tagblock"}},
+            { 0x58, new c{ T="Tagblock"}},
+            { 0x6C, new c{ T="Tagblock"}},
+            { 0x80, new c{ T="Tagblock"}},
+            { 0x94, new c{ T="Tagblock"}},
+            { 0xA8, new c{ T="Tagblock"}},
+
+            { 0xC0, new c{ T="4Byte"}},
+
+            { 0xC4, new c{ T="Tagblock"}},
+            { 0xD8, new c{ T="Tagblock"}},
+            { 0xEC, new c{ T="Tagblock"}},
+            { 0x100, new c{ T="Tagblock"}},
+            { 0x114, new c{ T="Tagblock"}},
+            { 0x128, new c{ T="Tagblock"}},
+            { 0x13C, new c{ T="Tagblock"}},
+            { 0x158, new c{ T="Tagblock"}},
+            { 0x16C, new c{ T="Tagblock"}},
+            { 0x180, new c{ T="Tagblock"}},
+            { 0x194, new c{ T="Tagblock"}},
+            { 0x1A8, new c{ T="Tagblock"}},
+            { 0x1BC, new c{ T="Tagblock"}},
+            { 0x1D0, new c{ T="Tagblock"}},
+            { 0x1F0, new c{ T="Tagblock"}},
+            { 0x204, new c{ T="Tagblock"}},
+
+
+
+        };
+
+        public static Dictionary<long, c> levlTag = new Dictionary<long, c>
+        {
+            { 0, new c{ T="Pointer"}},
+            { 8, new c{ T="4Byte"}}, // datnum
+            { 12, new c{ T="4Byte"}}, // tagID
+
+            { 0x10, new c{ T="Tagblock"}},
+            { 0x24, new c{ T="Tagblock"}},
+            { 0x38, new c{ T="Tagblock"}},
+            { 0x4C, new c{ T="Tagblock"}},
+
+            { 0x5C, new c{ T="4Byte"}},
+
+            { 0x60, new c{ T="Tagblock"}},
+            { 0x74, new c{ T="Tagblock"}},
+            { 0x88, new c{ T="Tagblock"}},
+            { 0x9C, new c{ T="Tagblock"}},
+            { 0xB0, new c{ T="Tagblock"}},
+            { 0xC4, new c{ T="Tagblock"}},
+            { 0xD8, new c{ T="Tagblock"}},
+            { 0xEC, new c{ T="Tagblock"}},
+            { 0x100, new c{ T="Tagblock"}},
+            { 0x114, new c{ T="Tagblock"}},
+            { 0x128, new c{ T="Tagblock"}},
+            { 0x13C, new c{ T="Tagblock"}},
+            { 0x150, new c{ T="Tagblock"}},
+            { 0x164, new c{ T="Tagblock"}},
+            { 0x178, new c{ T="Tagblock"}},
+            { 0x18C, new c{ T="Tagblock"}},
+            { 0x1A0, new c{ T="Tagblock"}},
+            { 0x1B4, new c{ T="Tagblock"}},
+            { 0x1C8, new c{ T="Tagblock"}},
+            { 0x1DC, new c{ T="Tagblock"}},
+            { 0x1F0, new c{ T="Tagblock"}},
+            { 0x204, new c{ T="Tagblock"}},
+            { 0x218, new c{ T="Tagblock"}},
+            { 0x22C, new c{ T="Tagblock"}},
+            { 0x240, new c{ T="Tagblock"}},
+            { 0x254, new c{ T="Tagblock"}},
+            { 0x268, new c{ T="Tagblock"}},
+            { 0x27C, new c{ T="Tagblock"}},
+            { 0x290, new c{ T="Tagblock"}},
+            { 0x2A4, new c{ T="Tagblock"}},
+            { 0x2B8, new c{ T="Tagblock"}},
+            { 0x2CC, new c{ T="Tagblock"}},
+            { 0x2E0, new c{ T="Tagblock"}},
+            { 0x2F4, new c{ T="Tagblock"}},
+            { 0x308, new c{ T="Tagblock"}},
+            { 0x31C, new c{ T="Tagblock"}},
+            { 0x330, new c{ T="Tagblock"}},
+            { 0x344, new c{ T="Tagblock"}},
+            { 0x358, new c{ T="Tagblock"}},
+            { 0x36C, new c{ T="Tagblock"}},
+            { 0x380, new c{ T="Tagblock"}},
+            { 0x394, new c{ T="Tagblock"}},
+            { 0x3A8, new c{ T="Tagblock"}},
+            { 0x3BC, new c{ T="Tagblock"}},
+            { 0x3D0, new c{ T="Tagblock"}},
+            { 0x3E4, new c{ T="Tagblock"}},
+            { 0x3F8, new c{ T="Tagblock"}},
+            { 0x40C, new c{ T="Tagblock"}},
+            { 0x420, new c{ T="Tagblock"}},
+            { 0x434, new c{ T="Tagblock"}},
+            { 0x448, new c{ T="Tagblock"}},
+            { 0x45C, new c{ T="Tagblock"}},
+            { 0x470, new c{ T="Tagblock"}},
+            { 0x484, new c{ T="Tagblock"}},
+            { 0x498, new c{ T="Tagblock"}},
+            { 0x4AC, new c{ T="Tagblock"}},
+            { 0x4C0, new c{ T="Tagblock"}},
+            { 0x4D4, new c{ T="Tagblock"}},
+            { 0x4E8, new c{ T="Tagblock"}},
+            { 0x4FC, new c{ T="Tagblock"}},
+            { 0x510, new c{ T="Tagblock"}},
+            { 0x524, new c{ T="Tagblock"}},
+            { 0x54C, new c{ T="Tagblock"}},
+            { 0x560, new c{ T="Tagblock"}},
+            { 0x574, new c{ T="Tagblock"}},
+            { 0x588, new c{ T="Tagblock"}},
+            { 0x59C, new c{ T="Tagblock"}},
+            { 0x5B0, new c{ T="Tagblock"}},
+            { 0x5C4, new c{ T="Tagblock"}},
+            { 0x5D8, new c{ T="Tagblock"}},
+            { 0x5EC, new c{ T="Tagblock"}},
+            { 0x600, new c{ T="Tagblock"}},
+            { 0x614, new c{ T="Tagblock"}},
+            { 0x628, new c{ T="Tagblock"}},
+            { 0x63C, new c{ T="Tagblock"}},
+            { 0x650, new c{ T="Tagblock"}},
+            { 0x664, new c{ T="Tagblock"}},
+            { 0x678, new c{ T="Tagblock"}},
+            { 0x68C, new c{ T="Tagblock"}},
+            { 0x6A0, new c{ T="Tagblock"}},
+            { 0x6B4, new c{ T="Tagblock"}},
+            { 0x6C8, new c{ T="Tagblock"}},
+            { 0x6DC, new c{ T="Tagblock"}},
+            { 0x6F0, new c{ T="Tagblock"}},
+            { 0x71C, new c{ T="Tagblock"}},
+
+            { 0x730, new c{ T="TagRef"}},
+            { 0x74C, new c{ T="TagRef"}},
+
+            { 0x788, new c{ T="Tagblock"}},
+
+            { 0x79C, new c{ T="TagRef"}},
+            { 0x7B8, new c{ T="TagRef"}},
+            { 0x7D4, new c{ T="TagRef"}},
+            { 0x7F0, new c{ T="TagRef"}},
+
+            { 0x80C, new c{ T="Tagblock"}},
+            { 0x820, new c{ T="Tagblock"}},
+
+            { 0x834, new c{ T="TagRef"}},
+
+            { 0x850, new c{ T="Tagblock"}},
+            { 0x864, new c{ T="Tagblock"}},
+            { 0x878, new c{ T="Tagblock"}},
+            { 0x88C, new c{ T="Tagblock"}},
+            { 0x8A0, new c{ T="Tagblock"}},
+            { 0x8B4, new c{ T="Tagblock"}},
+
+            { 0x8C8, new c{ T="TagRef"}},
+            { 0x8E4, new c{ T="TagRef"}},
+            { 0x900, new c{ T="TagRef"}},
+            { 0x91C, new c{ T="TagRef"}},
+            { 0x938, new c{ T="TagRef"}},
+
+            { 0x954, new c{ T="Tagblock"}},
+            { 0x968, new c{ T="Tagblock"}},
+            { 0x97C, new c{ T="Tagblock"}},
+            { 0x990, new c{ T="Tagblock"}},
+            { 0x9A4, new c{ T="Tagblock"}},
+            { 0x9B8, new c{ T="Tagblock"}},
+
+            { 0x9CC, new c{ T="TagRef"}},
+            { 0x9E8, new c{ T="TagRef"}},
+            { 0xA04, new c{ T="TagRef"}},
+            { 0xA20, new c{ T="TagRef"}},
+            { 0xA3C, new c{ T="TagRef"}},
+            { 0xA58, new c{ T="TagRef"}},
+            { 0xA74, new c{ T="TagRef"}},
+            { 0xA90, new c{ T="TagRef"}},
+            { 0xAAC, new c{ T="TagRef"}},
+
+            { 0xAE8, new c{ T="Tagblock"}},
+            { 0xAFC, new c{ T="Tagblock"}},
+            { 0xB10, new c{ T="Tagblock"}},
+            { 0xB24, new c{ T="Tagblock"}},
+
+            { 0xB38, new c{ T="TagRef"}},
+            { 0xB54, new c{ T="Tagblock"}},
+            { 0xB68, new c{ T="Tagblock"}},
+            { 0xB7C, new c{ T="TagRef"}},
+            { 0xB98, new c{ T="TagRef"}},
+
+            { 0xBB8, new c{ T="Tagblock"}},
+
+            { 0xBD4, new c{ T="TagRef"}},
+            { 0xBF0, new c{ T="TagRef"}},
+            { 0xC0C, new c{ T="TagRef"}},
+            { 0xC48, new c{ T="TagRef"}},
+            { 0xC64, new c{ T="TagRef"}},
+
+            { 0xC84, new c{ T="Tagblock"}},
+            { 0xCB4, new c{ T="Tagblock"}},
+            { 0xCC8, new c{ T="Tagblock"}},
+            { 0xCDC, new c{ T="Tagblock"}}
+        };
     }
 }

--- a/Interface/Controls/TagBlock.xaml
+++ b/Interface/Controls/TagBlock.xaml
@@ -17,10 +17,10 @@
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto" MinHeight="3"/>
         </Grid.RowDefinitions>
-        <TextBlock x:Name="tagblock_title" Text="Tag block description" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Margin="5,0,0,0"/>
+        <TextBlock x:Name="tagblock_title" Text="Tag block description" VerticalAlignment="Bottom" Grid.ColumnSpan="2" Margin="5,0,0,0" Foreground="White" />
 
         <TextBox x:Name="tagblock_address" Text="Tag block address" Grid.Row="1" Margin="5,0,0,0"/>
-        <TextBlock Text="Count" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" Margin="0,0,8,0"/>
+        <TextBlock Text="Count" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" Margin="0,0,8,0" Foreground="White"/>
         <TextBox x:Name="tagblock_count" Text="-" Grid.Row="1" Grid.Column="2"/>
 
         <StackPanel x:Name="dockpanel" Background="Gray" Grid.Row="3" Grid.ColumnSpan="4">

--- a/Interface/Controls/TagBlock.xaml
+++ b/Interface/Controls/TagBlock.xaml
@@ -23,11 +23,7 @@
         <TextBlock Text="Count" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" Margin="0,0,8,0" Foreground="White"/>
         <TextBox x:Name="tagblock_count" Text="-" Grid.Row="1" Grid.Column="2"/>
 
-        <StackPanel x:Name="dockpanel" Background="Gray" Grid.Row="3" Grid.ColumnSpan="4">
-
-        </StackPanel>
+        <StackPanel x:Name="dockpanel" Background="Gray" Grid.Row="3" Grid.ColumnSpan="4" />
         <ComboBox x:Name="indexbox" Grid.Column="2" Margin="2,2,0,2" SelectionChanged="indexbox_SelectionChanged"  />
-
-
     </Grid>
 </UserControl>

--- a/Interface/Controls/TagEditorControl.xaml
+++ b/Interface/Controls/TagEditorControl.xaml
@@ -11,14 +11,12 @@
             <ColumnDefinition Width="10"/>
             <ColumnDefinition />
             <ColumnDefinition Width="130"/>
-            <ColumnDefinition Width="10"/>
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
             <RowDefinition Height="20"/>
             <RowDefinition Height="20"/>
             <RowDefinition />
-            <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
 
         <TextBox x:Name="Tagname_text"    Text="Tag Name" Grid.Column="1" />
@@ -28,10 +26,8 @@
         <TextBox x:Name="tagdatnum_text"  Text="Datnum: 00000000" Grid.Column="2" Grid.Row="1"/>
 
         <ScrollViewer BorderBrush="Black" BorderThickness="1" Grid.Row="2" Grid.ColumnSpan="3">
-            <StackPanel x:Name="tagview_panels"  Margin="0,0,0,0" />
+            <StackPanel x:Name="tagview_panels"  Margin="0,5,0,10" />
         </ScrollViewer>
-
-       
 
         <Grid Grid.Row="4" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>

--- a/Interface/Controls/TagEditorControl.xaml
+++ b/Interface/Controls/TagEditorControl.xaml
@@ -46,8 +46,6 @@
                 <RowDefinition Height="20"/>
                 <RowDefinition />
             </Grid.RowDefinitions>
-
-            
         </Grid>
     </Grid>
 </UserControl>

--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -19,15 +19,18 @@ using System.Windows.Shapes;
 
 using static Assembly69.MainWindow;
 
-namespace Assembly69.Interface.Controls {
+namespace Assembly69.Interface.Controls
+{
     /// <summary>
     /// Interaction logic for TagEditorControl.xaml
     /// </summary>
-    public partial class TagEditorControl : UserControl {
+    public partial class TagEditorControl : UserControl
+    {
         MainWindow mainWindow;
         Mem m;
 
-        public TagEditorControl(MainWindow mw) {
+        public TagEditorControl(MainWindow mw)
+        {
             this.mainWindow = mw;
             this.m = mainWindow.m;
 
@@ -44,45 +47,68 @@ namespace Assembly69.Interface.Controls {
 
             tagview_panels.Children.Clear();
 
-            if (loading_tag.Tag_group == "vehi") {
+            if (loading_tag.Tag_group == "vehi") // i keep forgetting how switches work so i haven't changed this yet
+            {
 
                 Dictionary<long, vehi.c> strings = vehi.VehicleTag;
                 do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
-            } else if (loading_tag.Tag_group == "weap") {
+            }
+            else if (loading_tag.Tag_group == "weap")
+            {
 
                 Dictionary<long, vehi.c> strings = vehi.WeaponTag;
                 do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
-            } else if (loading_tag.Tag_group == "proj") {
+            }
+            else if (loading_tag.Tag_group == "proj")
+            {
 
                 Dictionary<long, vehi.c> strings = vehi.projectileTag;
                 do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
-            } else if (loading_tag.Tag_group == "hlmt") {
+            }
+            else if (loading_tag.Tag_group == "hlmt")
+            {
 
                 Dictionary<long, vehi.c> strings = vehi.HLMTTag;
                 do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
             }
+            else if (loading_tag.Tag_group == "sddt")
+            {
+
+                Dictionary<long, vehi.c> strings = vehi.sddtTag;
+                do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
+            }
+            else if (loading_tag.Tag_group == "levl")
+            {
+
+                Dictionary<long, vehi.c> strings = vehi.levlTag;
+                do_the_tag_thing(strings, loading_tag.Tag_data, tagview_panels);
+            }
         }
 
-        
+
         // hmm we need a system that reads the pointer and adds it
         // also, we need to beable to read multiple tag things but i may put that on hold
-        public void recall_blockloop(KeyValuePair<long, vehi.c> entry, long loading_tag, StackPanel parentpanel) {
+        public void recall_blockloop(KeyValuePair<long, vehi.c> entry, long loading_tag, StackPanel parentpanel)
+        {
             parentpanel.Children.Clear();
-            if (entry.Value.B != null) {
+            if (entry.Value.B != null)
+            {
                 do_the_tag_thing(entry.Value.B, loading_tag, parentpanel);
             }
         }
 
 
         // for text boxes
-        private void value_TextChanged(object sender, TextChangedEventArgs e) {
+        private void value_TextChanged(object sender, TextChangedEventArgs e)
+        {
             TextBox tb = sender as TextBox;
             string[] s = tb.Tag.ToString().Split(":");
             mainWindow.addpokechange(long.Parse(s[0]), s[1], tb.Text);
         }
 
         // for tag group
-        private void taggroup_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+        private void taggroup_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
             ComboBox cb = sender as ComboBox;
 
             mainWindow.addpokechange(long.Parse(cb.Tag.ToString()), "TagrefGroup", cb.SelectedValue.ToString());
@@ -94,19 +120,22 @@ namespace Assembly69.Interface.Controls {
             // THAT WAS PROBABLY THE MOST DODGY THING IVE EVER DONE WTFFFF
         }
 
-        public void gotobutton(object sender, RoutedEventArgs e) {
+        public void gotobutton(object sender, RoutedEventArgs e) 
+        {
             Button b = sender as Button;
             int w = int.Parse(b.Tag.ToString());
             if (w != -1)
                 inhale_tag(w);
         }
 
-        private void tagrefbutton(object sender, RoutedEventArgs e) {
+        private void tagrefbutton(object sender, RoutedEventArgs e)
+        {
             Button b = sender as Button;
 
             string[] s = b.Tag.ToString().Split(":");
 
-            if (s.Length > 1) {
+            if (s.Length > 1)
+            {
                 mainWindow.trd = new TagRefDropdown();
 
                 var myButtonLocation = b.PointToScreen(new Point(0, 0));
@@ -130,8 +159,10 @@ namespace Assembly69.Interface.Controls {
                 item.Selected += new RoutedEventHandler(update_tagref);
 
 
-                foreach (tag_struct tg in mainWindow.Tags_List) {
-                    if (tg.Tag_group == s[1]) {
+                foreach (tag_struct tg in mainWindow.Tags_List)
+                {
+                    if (tg.Tag_group == s[1])
+                    {
                         TreeViewItem testing = new TreeViewItem();
 
                         testing.Header = mainWindow.convert_ID_to_tag_name(tg.ObjectID);
@@ -148,7 +179,8 @@ namespace Assembly69.Interface.Controls {
 
 
         // this is for our dropdown thingo for changing tag refs
-        public void update_tagref(object sender, RoutedEventArgs e) {
+        public void update_tagref(object sender, RoutedEventArgs e)
+        {
             TreeViewItem b = sender as TreeViewItem;
 
             string[] s = b.Tag.ToString().Split(":");
@@ -157,121 +189,146 @@ namespace Assembly69.Interface.Controls {
             string ID = mainWindow.get_tagid_by_datnum(s[1]);
             mainWindow.the_last_tagref_button_we_pressed.Content = mainWindow.convert_ID_to_tag_name(ID);
 
-            // need to do this the lazy way again, have to head off in a sec
+            // need to do this the lazy way again, have to head off in a sec, no i am not going to fix this 
+            // if someone ends up here, then likely someone has changed the tagref block UI and its broken
             Grid td = mainWindow.the_last_tagref_button_we_pressed.Parent as Grid;
             Button X = td.Children[2] as Button;
-            X.Tag = ID;
 
-            if (mainWindow.trd != null) {
+            X.Tag = mainWindow.get_tagindex_by_datnum(s[1]); // theres one of our problems, we were still using tagID rather than tag index
+
+            if (mainWindow.trd != null)
+            {
                 mainWindow.trd.closethis();
             }
         }
 
-        // had to adapt this to bealbe to read tagblocks and forgot to allow it to iterate through them *sigh* good enough for now
-        void do_the_tag_thing(Dictionary<long, vehi.c> VehicleTag, long address, StackPanel parentpanel) {
-            foreach (KeyValuePair<long, vehi.c> entry in VehicleTag) {
-                switch (entry.Value.T) {
-                case "4Byte":
-                    TagValueBlock vb1 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
-                    vb1.value_type.Text = "4 Byte";
-                    vb1.value.Text = m.ReadInt((+entry.Key).ToString("X")).ToString();
-                    parentpanel.Children.Add(vb1);
+        // had to adapt this to bealbe to read tagblocks
+        void do_the_tag_thing(Dictionary<long, vehi.c> VehicleTag, long address, StackPanel parentpanel)
+        {
+            foreach (KeyValuePair<long, vehi.c> entry in VehicleTag)
+            {
+                switch (entry.Value.T)
+                {
+                    case "4Byte":
+                        TagValueBlock vb1 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
+                        vb1.value_type.Text = "4 Byte";
+                        vb1.value.Text = m.ReadInt((+entry.Key).ToString("X")).ToString();
+                        parentpanel.Children.Add(vb1);
 
-                    vb1.value.Tag = address + entry.Key + ":4Byte";
-                    vb1.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
-                    break;
-                case "Float":
-                    TagValueBlock vb2 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
-                    vb2.value_type.Text = "Float";
-                    vb2.value.Text = m.ReadFloat((address + entry.Key).ToString("X")).ToString();
-                    parentpanel.Children.Add(vb2);
+                        vb1.value.Tag = address + entry.Key + ":4Byte";
+                        vb1.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        break;
+                    case "Float":
+                        TagValueBlock vb2 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
+                        vb2.value_type.Text = "Float";
+                        vb2.value.Text = m.ReadFloat((address + entry.Key).ToString("X")).ToString();
+                        parentpanel.Children.Add(vb2);
 
-                    vb2.value.Tag = address + entry.Key + ":Float";
-                    vb2.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
-                    break; 
-                case "TagRef":
-                    TagRefBlock tfb1 = new TagRefBlock { HorizontalAlignment = HorizontalAlignment.Left };
-                    foreach (string s in mainWindow.Tag_groups.Keys) {
-                        tfb1.taggroup.Items.Add(s);
-                    }
-                    string test_group = ReverseString(m.ReadString((address + entry.Key + 20).ToString("X"), "", 4));
-                    tfb1.taggroup.SelectedItem = test_group;
+                        vb2.value.Tag = address + entry.Key + ":Float";
+                        vb2.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        break;
+                    case "TagRef":
+                        TagRefBlock tfb1 = new TagRefBlock { HorizontalAlignment = HorizontalAlignment.Left };
+                        foreach (string s in mainWindow.Tag_groups.Keys)
+                        {
+                            tfb1.taggroup.Items.Add(s);
+                        }
+                        string test_group = ReverseString(m.ReadString((address + entry.Key + 20).ToString("X"), "", 4));
+                        tfb1.taggroup.SelectedItem = test_group;
 
-                    // read tagID rather than datnum // or rather, convert datnum to ID
-                    string test = BitConverter.ToString(m.ReadBytes((address + entry.Key + 24).ToString("X"), 4)).Replace("-", string.Empty);
-                    string test_nameID = mainWindow.convert_ID_to_tag_name(mainWindow.get_tagid_by_datnum(test));
+                        // read tagID rather than datnum // or rather, convert datnum to ID
+                        string test = BitConverter.ToString(m.ReadBytes((address + entry.Key + 24).ToString("X"), 4)).Replace("-", string.Empty);
+                        string test_nameID = mainWindow.convert_ID_to_tag_name(mainWindow.get_tagid_by_datnum(test));
 
-                    tfb1.tag_button.Content = test_nameID;
-                    parentpanel.Children.Add(tfb1);
+                        tfb1.tag_button.Content = test_nameID;
+                        parentpanel.Children.Add(tfb1);
 
-                    tfb1.taggroup.Tag = (address + entry.Key + 20);
-                    tfb1.taggroup.SelectionChanged += new SelectionChangedEventHandler(taggroup_SelectionChanged);
+                        tfb1.taggroup.Tag = (address + entry.Key + 20);
+                        tfb1.taggroup.SelectionChanged += new SelectionChangedEventHandler(taggroup_SelectionChanged);
 
-                    tfb1.tag_button.Tag = (address + entry.Key + 24) + ":" + test_group;
-                    tfb1.tag_button.Click += new RoutedEventHandler(tagrefbutton);
+                        tfb1.tag_button.Tag = (address + entry.Key + 24) + ":" + test_group;
+                        tfb1.tag_button.Click += new RoutedEventHandler(tagrefbutton);
 
-                    int ID = mainWindow.get_tagindex_by_datnum(test);
+                        int ID = mainWindow.get_tagindex_by_datnum(test); // do this for the "goto" button too // we forgot
 
-                    tfb1.goto_button.Tag = ID; // need to get the index of the tag not the ID
-                    tfb1.goto_button.Click += new RoutedEventHandler(gotobutton);
+                        tfb1.goto_button.Tag = ID; // need to get the index of the tag not the ID
+                        tfb1.goto_button.Click += new RoutedEventHandler(gotobutton);
 
-                    break;
-                case "Pointer":
-                    TagValueBlock vb3 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
-                    vb3.value_type.Text = "Pointer";
-                    vb3.value.Text = m.ReadLong((address + entry.Key).ToString("X")).ToString("X");
-                    parentpanel.Children.Add(vb3);
+                        break;
+                    case "Pointer":
+                        TagValueBlock vb3 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
+                        vb3.value_type.Text = "Pointer";
+                        vb3.value.Text = m.ReadLong((address + entry.Key).ToString("X")).ToString("X");
+                        parentpanel.Children.Add(vb3);
 
-                    vb3.value.Tag = address + entry.Key + ":Pointer";
-                    vb3.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
-                    break;
-                case "Tagblock": // need to find some kinda "whoops that tag isnt actually loaded"; keep erroring with the hlmt tag
-                    TagBlock tb1 = new TagBlock (this) { HorizontalAlignment = HorizontalAlignment.Left };
-                    long new_address = m.ReadLong((address + entry.Key).ToString("X"));
-                    tb1.tagblock_address.Text = "0x" + new_address.ToString("X");
-                    if (new_address != 0x100000000)
-                        tb1.tagblock_title.Text = m.ReadString((address + entry.Key + 8).ToString("X") + ",0,0");
-                    string children_count = m.ReadInt((address + entry.Key + 16).ToString("X")).ToString();
-                    tb1.tagblock_count.Text = children_count;
-                    parentpanel.Children.Add(tb1);
+                        vb3.value.Tag = address + entry.Key + ":Pointer";
+                        vb3.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        break;
+                    case "Tagblock": // need to find some kinda "whoops that tag isnt actually loaded"; keep erroring with the hlmt tag
+                        TagBlock tb1 = new TagBlock(this) { HorizontalAlignment = HorizontalAlignment.Left };
+                        long new_address = m.ReadLong((address + entry.Key).ToString("X"));
+                        tb1.tagblock_address.Text = "0x" + new_address.ToString("X");
 
-                    tb1.tagblock_address.Tag = (address + entry.Key) + ":Pointer";
-                    tb1.tagblock_address.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        long string_address = m.ReadLong((address + entry.Key + 8).ToString("X"));
+                        if (string_address < 0x80233F6E && string_address > 0x20233F6E)
+                        {
+                            tb1.tagblock_title.Text = m.ReadString((address + entry.Key + 8).ToString("X") + ",0,0"); // this is the only thing that causes errors with unloaded tags
 
-                    tb1.tagblock_count.Tag = (address + entry.Key + 16) + ":4Byte";
-                    tb1.tagblock_count.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        }
+                        else
+                        {
+                            tb1.tagblock_title.Text = "Error: tag Unloaded";
+                            parentpanel.Children.Add(tb1);
+                            break;
+                        }
 
-                    //tb1.indexbox.SelectionChanged += new SelectionChangedEventHandler(indexbox_SelectionChanged);
+                        string children_count = m.ReadInt((address + entry.Key + 16).ToString("X")).ToString();
+                        tb1.tagblock_count.Text = children_count;
+                        parentpanel.Children.Add(tb1);
 
-                    tb1.children = entry;
-                    tb1.block_address = new_address;
+                        tb1.tagblock_address.Tag = (address + entry.Key) + ":Pointer";
+                        tb1.tagblock_address.TextChanged += new TextChangedEventHandler(value_TextChanged);
 
-                    int childs = int.Parse(children_count);
-                    for (int y = 0; y < childs; y++) {
-                        tb1.indexbox.Items.Add(new ListViewItem { Content = y });
-                    }
-                    if (childs > 0) {
-                        tb1.indexbox.SelectedIndex = 0;
+                        tb1.tagblock_count.Tag = (address + entry.Key + 16) + ":4Byte";
+                        tb1.tagblock_count.TextChanged += new TextChangedEventHandler(value_TextChanged);
 
-                    } else {
-                        tb1.indexbox.IsEnabled = false;
-                    }
+                        //tb1.indexbox.SelectionChanged += new SelectionChangedEventHandler(indexbox_SelectionChanged);
 
-                    //recall_blockloop(entry, new_address, tb1.dockpanel);
-                    break;
+                        tb1.children = entry;
+                        tb1.block_address = new_address;
 
-                case "String":
-                    TagValueBlock vb4 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
-                    vb4.value_type.Text = "String";
-                    vb4.value.Text = m.ReadString((address + entry.Key).ToString("X")).ToString();
-                    parentpanel.Children.Add(vb4);
+                        int childs = int.Parse(children_count);
+                        for (int y = 0; y < childs; y++)
+                        {
+                            tb1.indexbox.Items.Add(new ListViewItem { Content = y });
+                        }
+                        if (childs > 0)
+                        {
+                            tb1.indexbox.SelectedIndex = 0;
 
-                    vb4.value.Tag = address + entry.Key + ":String";
-                    vb4.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
-                    break;
+                        }
+                        else
+                        {
+                            tb1.indexbox.IsEnabled = false;
+                        }
+
+                        //recall_blockloop(entry, new_address, tb1.dockpanel);
+                        break;
+
+                    case "String":
+                        TagValueBlock vb4 = new TagValueBlock { HorizontalAlignment = HorizontalAlignment.Left };
+                        vb4.value_type.Text = "String";
+                        vb4.value.Text = m.ReadString((address + entry.Key).ToString("X")).ToString();
+                        parentpanel.Children.Add(vb4);
+
+                        vb4.value.Tag = address + entry.Key + ":String";
+                        vb4.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
+                        break;
 
                 }
             }
         }
+
+        // hey where'd the rest go lol
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -54,7 +54,7 @@ namespace Assembly69 {
 
             if (validtest == "tag instances") {
                 hook_text.Text = "Process Hooked";
-            } else {
+            } else { // eww
                 hook_text.Text = "Offset failed, scanning...";
 
                 long? aobScan = (await m.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))


### PR DESCRIPTION
Fixed the goto button not working correctly, in the current form it'll replace the current tab's contents instead of opening a new tab. This screws up the system searching if an tab exists already and shows it.

Now it will open the tag in a new tab, if you wish it to replace the current tab let me know and I'll rewrite the implementation to do so.