### PR TITLE
Fixed Popup Window location & Added VS19+ editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,119 @@
+# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Programming\Modding\Halo Infinite\Infinite-runtime-tagviewer\ codebase based on best match to current usage at 09/12/2021
+# You can modify the rules from these initially generated values to suit your own policies
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - indentation options
+
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require braces to be on a new line for types, control_blocks, and methods (also known as "Allman" style)
+csharp_new_line_before_open_brace = types, control_blocks, methods
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require a space between a cast and the value
+csharp_space_after_cast = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+
+#Style - Code block preferences
+
+#prefer curly braces even for one line of code
+csharp_prefer_braces = true:suggestion
+
+#Style - expression bodied member options
+
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration = true:suggestion
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer default(T) over default
+csharp_prefer_simple_default_expression = false:suggestion
+#prefer objects to be initialized using object initializers when possible
+dotnet_style_object_initializer = true:suggestion
+
+#Style - implicit and explicit types
+
+#prefer explicit type over var in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = false:suggestion
+#prefer explicit type over var to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = false:suggestion
+#prefer explicit type over var when the type is already mentioned on the right-hand side of a declaration
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,private,static,async:suggestion
+
+#Style - Pattern matching
+
+#prefer is expression with type casts instead of pattern matching
+csharp_style_pattern_matching_over_as_with_null_check = false:suggestion
+
+#Style - qualification options
+
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -155,11 +155,39 @@ namespace Assembly69.Interface.Controls {
                 var trdWidth = trd.Width = b.ActualWidth + 116;
                 var trdHeight = trd.Height = 400;
 
+                // TODO figure out how to do this on popped out windows
+                Window controlsWindow = GetTopLevelControlOfType<Window>((DependencyObject) sender);
 
-                var myButtonLocation = b.PointToScreen(new Point(0, 0));
+                var wind = Window.GetWindow(b);
 
-                trd.Left = myButtonLocation.X - 8;
-                trd.Top = myButtonLocation.Y + 1;
+                // There seems to be no way to get the window
+                // that the control is assigned to, I'll come up with
+                // a solution soon.
+                var ld = this.LayoutDocument;
+                LayoutDocumentPane ldp = ld.Parent as LayoutDocumentPane;
+                var dockingWindow = ldp.FindParent<LayoutDocumentFloatingWindow>();
+
+                // If we can get the topmost window, use a precise approach
+                if (controlsWindow != null) {
+                    // Get the control's point relative to the parent window.
+                    Point relativeControlLocation = b.TranslatePoint(new Point(0, b.ActualHeight), controlsWindow);
+                    
+                    // Set the location to the parent window + control location
+                    // This sets it to just above the control, by adding the height by a factor of 1.5 it seems
+                    // to be an almost fit. 
+                    trd.Left = controlsWindow.Left + relativeControlLocation.X;
+                    trd.Top  = controlsWindow.Top  + relativeControlLocation.Y + (b.ActualHeight * 1.5);
+                }
+                // else if (dockingWindow != null) {
+                //     //Point relativeControlLocation = b.TranslatePoint(new Point(0, b.ActualHeight), dockingWindow);
+                // }
+                // If we cannot find the topmost window, use 
+                else {
+                    var myButtonLocation = b.PointToScreen(new Point(0, 0));
+                    
+                    trd.Left = myButtonLocation.X - 8;
+                    trd.Top = myButtonLocation.Y + 1;
+                }
 
                 trd.MainWindow = mainWindow;
                 mainWindow.the_last_tagref_button_we_pressed = b;

--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -161,7 +161,7 @@ namespace Assembly69.Interface.Controls
                 System.Diagnostics.Debug.WriteLine("- " + tmp.GetType());
 
                 if (tmp is T)
-                    target = (T)tmp;
+                    target = (T) tmp;
             }
 
             return target;
@@ -204,23 +204,25 @@ namespace Assembly69.Interface.Controls
                 var dockingWindow = ldp.FindParent<LayoutDocumentFloatingWindow>();
 
                 // If we can get the topmost window, use a precise approach
-                if (controlsWindow != null) {
+                if (controlsWindow != null)
+                {
                     // Get the control's point relative to the parent window.
                     Point relativeControlLocation = b.TranslatePoint(new Point(0, b.ActualHeight), controlsWindow);
-                    
+
                     // Set the location to the parent window + control location
                     // This sets it to just above the control, by adding the height by a factor of 1.5 it seems
                     // to be an almost fit. 
                     trd.Left = controlsWindow.Left + relativeControlLocation.X;
-                    trd.Top  = controlsWindow.Top  + relativeControlLocation.Y + (b.ActualHeight * 1.5);
+                    trd.Top = controlsWindow.Top + relativeControlLocation.Y + (b.ActualHeight * 1.5);
                 }
                 // else if (dockingWindow != null) {
                 //     //Point relativeControlLocation = b.TranslatePoint(new Point(0, b.ActualHeight), dockingWindow);
                 // }
                 // If we cannot find the topmost window, use 
-                else {
+                else
+                {
                     var myButtonLocation = b.PointToScreen(new Point(0, 0));
-                    
+
                     trd.Left = myButtonLocation.X - 8;
                     trd.Top = myButtonLocation.Y + 1;
                 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -67,8 +67,7 @@ namespace Assembly69 {
                 long? aobScan = (await m.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))
                 .First(); // "tag instances"
 
-                // Failed to find base tag address+		dockManager	{AvalonDock.DockingManager}	AvalonDock.DockingManager
-
+                // Failed to find base tag address
                 if (aobScan == null || aobScan == 0) {
                     base_address = -1;
                     hook_text.Text = "Failed to locate base tag address";


### PR DESCRIPTION
Added editorconfig to enforce the prefered bracket / coding style of Gamergotten. Removing the annoyingly inaccurate diffs to see what changes occured.

AvalonDock annoyingly wont let us know where control is under what window, I found a way to get the window by working backwards using the window as a base and then figuring out where our content host is located. 

The dropdown will now appear under the control on both the main window and any dragged out windows.