### PR TITLE
Fix Many Issues

### DIFF
--- a/Extension.cs
+++ b/Extension.cs
@@ -18,11 +18,13 @@ namespace Assembly69
         {
             if (window.WindowState == WindowState.Maximized)
             {
-                var leftField = typeof(Window).GetField("_actualLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo? leftField = typeof(Window).GetField("_actualLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 return (double) leftField.GetValue(window);
             }
             else
+            {
                 return window.Left;
+            }
         }
 
         /// <summary>
@@ -34,11 +36,13 @@ namespace Assembly69
         {
             if (window.WindowState == WindowState.Maximized)
             {
-                var topField = typeof(Window).GetField("_actualTop", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                System.Reflection.FieldInfo? topField = typeof(Window).GetField("_actualTop", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 return (double) topField.GetValue(window);
             }
             else
+            {
                 return window.Top;
+            }
         }
 
         public static bool GetBit(this byte b, int bitNumber)

--- a/Halo/TagObjects/vehi.cs
+++ b/Halo/TagObjects/vehi.cs
@@ -12,8 +12,8 @@ namespace Assembly69.Halo.TagObjects
 
         public class C
         {
-            public string T { get; set; }
-            public Dictionary<long, C> B { get; set; }
+            public string? T { get; set; }
+            public Dictionary<long, C>? B { get; set; }
 
             /// <summary>
             /// Length of the tagblock

--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -362,27 +362,32 @@ namespace Assembly69.Interface.Controls
                         }
                         string testGroup = ReverseString(_m.ReadString((address + entry.Key + 20).ToString("X"), "", 4));
                         tfb1.taggroup.SelectedItem = testGroup;
-
                         // read tagID rather than datnum // or rather, convert datnum to ID
-                        string test = BitConverter.ToString(_m.ReadBytes((address + entry.Key + 24).ToString("X"), 4)).Replace("-", string.Empty);
-                        string testNameId = _mainWindow.convert_ID_to_tag_name(_mainWindow.get_tagid_by_datnum(test));
+                        try
+                        {
+                            string test = BitConverter.ToString(_m.ReadBytes((address + entry.Key + 24).ToString("X"), 4)).Replace("-", string.Empty);
+                            string testNameId = _mainWindow.convert_ID_to_tag_name(_mainWindow.get_tagid_by_datnum(test));
 
-                        tfb1.tag_button.Content = testNameId;
-                        parentpanel.Children.Add(tfb1);
+                            tfb1.tag_button.Content = testNameId;
+                            parentpanel.Children.Add(tfb1);
 
-                        tfb1.taggroup.Tag = (address + entry.Key + 20);
-                        tfb1.taggroup.SelectionChanged += new SelectionChangedEventHandler(taggroup_SelectionChanged);
+                            tfb1.taggroup.Tag = (address + entry.Key + 20);
+                            tfb1.taggroup.SelectionChanged += new SelectionChangedEventHandler(taggroup_SelectionChanged);
 
-                        tfb1.tag_button.Tag = (address + entry.Key + 24) + ":" + testGroup;
-                        tfb1.tag_button.Click += new RoutedEventHandler(Tagrefbutton);
+                            tfb1.tag_button.Tag = (address + entry.Key + 24) + ":" + testGroup;
+                            tfb1.tag_button.Click += new RoutedEventHandler(Tagrefbutton);
 
-                        int id = _mainWindow.get_tagindex_by_datnum(test);
+                            int id = _mainWindow.get_tagindex_by_datnum(test);
 
-                        // tag
+                            // tag
 
-                        tfb1.goto_button.Tag = id; // need to get the index of the tag not the ID
-                        tfb1.goto_button.Click += new RoutedEventHandler(Gotobutton);
-
+                            tfb1.goto_button.Tag = id; // need to get the index of the tag not the ID
+                            tfb1.goto_button.Click += new RoutedEventHandler(Gotobutton);
+                        }
+                        catch
+                        {
+                            break;
+                        }
                         break;
 
                     case "Pointer":

--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Diagnostics;
 using Assembly69.Halo.TagObjects;
 using Assembly69.Interface.Windows;
 using AvalonDock.Controls;
@@ -20,19 +21,19 @@ namespace Assembly69.Interface.Controls
     public partial class TagEditorControl
     {
         private MainWindow _mainWindow;
-        private Mem _m;
+        private readonly Mem _m;
 
-        public LayoutDocument LayoutDocument { get; internal set; }
+        public LayoutDocument? LayoutDocument { get; internal set; }
 
         public TagEditorControl(MainWindow mw)
         {
-            this._mainWindow = mw;
-            this._m = _mainWindow.M;
+            _mainWindow = mw;
+            _m = _mainWindow.M;
 
             InitializeComponent();
         }
 
-        public void inhale_tag(int tagIndex) // as in a literal index to the tag
+        public void Inhale_tag(int tagIndex) // as in a literal index to the tag
         {
             TagStruct loadingTag = _mainWindow.TagsList[tagIndex];
             Tagname_text.Text = _mainWindow.convert_ID_to_tag_name(loadingTag.ObjectId);
@@ -109,7 +110,7 @@ namespace Assembly69.Interface.Controls
         // for text boxes
         private void value_TextChanged(object sender, TextChangedEventArgs e)
         {
-            TextBox tb = sender as TextBox;
+            TextBox? tb = sender as TextBox;
             string[] s = tb.Tag.ToString().Split(":");
             _mainWindow.Addpokechange(long.Parse(s[0]), s[1], tb.Text);
         }
@@ -117,12 +118,12 @@ namespace Assembly69.Interface.Controls
         // for tag group
         private void taggroup_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            ComboBox cb = sender as ComboBox;
+            ComboBox? cb = sender as ComboBox;
 
-            _mainWindow.Addpokechange(long.Parse(cb.Tag.ToString()), "TagrefGroup", cb.SelectedValue.ToString());
+            _mainWindow.Addpokechange(long.Parse(s: cb.Tag.ToString()), "TagrefGroup", value: cb.SelectedValue.ToString());
 
-            Grid td = cb.Parent as Grid;
-            Button b = td.Children[1] as Button;
+            Grid? td = cb.Parent as Grid;
+            Button? b = td.Children[1] as Button;
             string[] s = b.Tag.ToString().Split(":");
             b.Tag = s[0] + ":" + cb.SelectedValue.ToString();
             // THAT WAS PROBABLY THE MOST DODGY THING IVE EVER DONE WTFFFF
@@ -130,8 +131,8 @@ namespace Assembly69.Interface.Controls
 
         public void Gotobutton(object sender, RoutedEventArgs e)
         {
-            Button b = sender as Button;
-            var sTagId = b.Tag.ToString();
+            Button? b = sender as Button;
+            string? sTagId = b.Tag.ToString();
             int iTagId = int.Parse(sTagId);
 
             if (iTagId != -1)
@@ -142,8 +143,8 @@ namespace Assembly69.Interface.Controls
 
         private DependencyObject GetTopLevelControl(DependencyObject control)
         {
-            DependencyObject tmp = control;
-            DependencyObject parent = null;
+            DependencyObject? tmp = control;
+            DependencyObject? parent = null;
             while ((tmp = VisualTreeHelper.GetParent(tmp)) != null)
             {
                 parent = tmp;
@@ -153,7 +154,7 @@ namespace Assembly69.Interface.Controls
 
         private T? GetTopLevelControlOfType<T>(DependencyObject control) where T : DependencyObject
         {
-            DependencyObject tmp = control;
+            DependencyObject? tmp = control;
             T? target = default(T);
 
             while ((tmp = VisualTreeHelper.GetParent(tmp)) != null)
@@ -192,17 +193,17 @@ namespace Assembly69.Interface.Controls
 
         private void Tagrefbutton(object sender, RoutedEventArgs e)
         {
-            Button b = sender as Button;
+            Button? b = sender as Button;
             string[] s = b.Tag.ToString().Split(":");
 
             if (s.Length > 1)
             {
-                var trd = _mainWindow.Trd = new TagRefDropdown();
-                var trdWidth = trd.Width = b.ActualWidth + 116;
-                var trdHeight = trd.Height = 400;
+                TagRefDropdown? trd = _mainWindow.Trd = new TagRefDropdown();
+                double trdWidth = trd.Width = b.ActualWidth + 116;
+                double trdHeight = trd.Height = 400;
 
                 //
-                Window controlsWindow = GetTopLevelControlOfType<Window>((DependencyObject) sender);
+                Window? controlsWindow = GetTopLevelControlOfType<Window>((DependencyObject) sender);
 
                 // There seems to be no way to get the window, so we will find the LayoutDocumentPaneGroupControl
                 // instead and we can use that to crawl backwards through the Windows to find it.
@@ -271,7 +272,7 @@ namespace Assembly69.Interface.Controls
                 trd.MainWindow = _mainWindow;
                 _mainWindow.TheLastTagrefButtonWePressed = b;
 
-                TreeViewItem item = new() {
+                TreeViewItem? item = new() {
                     Header = _mainWindow.convert_ID_to_tag_name("FFFFFFFF"),
                     Tag = s[0] + ":" + "FFFFFFFF"
                 };
@@ -283,7 +284,7 @@ namespace Assembly69.Interface.Controls
                 {
                     if (tg.TagGroup == s[1])
                     {
-                        TreeViewItem testing = new() {
+                        TreeViewItem? testing = new() {
                             Header = _mainWindow.convert_ID_to_tag_name(tg.ObjectId),
                             Tag = s[0] + ":" + tg.Datnum
                         };
@@ -300,7 +301,7 @@ namespace Assembly69.Interface.Controls
         // this is for our dropdown thingo for changing tag refs
         public void update_tagref(object sender, RoutedEventArgs e)
         {
-            TreeViewItem b = sender as TreeViewItem;
+            TreeViewItem? b = sender as TreeViewItem;
 
             string[] s = b.Tag.ToString().Split(":");
             _mainWindow.Addpokechange(long.Parse(s[0]), "TagrefTag", s[1]);
@@ -309,8 +310,8 @@ namespace Assembly69.Interface.Controls
             _mainWindow.TheLastTagrefButtonWePressed.Content = _mainWindow.convert_ID_to_tag_name(id);
 
             // need to do this the lazy way again, have to head off in a sec
-            Grid td = _mainWindow.TheLastTagrefButtonWePressed.Parent as Grid;
-            Button x = td.Children[2] as Button;
+            Grid? td = _mainWindow.TheLastTagrefButtonWePressed.Parent as Grid;
+            Button? x = td.Children[2] as Button;
             //X.Tag = ID;
 
             x.Tag = _mainWindow.get_tagindex_by_datnum(s[1]);
@@ -330,7 +331,7 @@ namespace Assembly69.Interface.Controls
                 switch (entry.Value.T)
                 {
                     case "4Byte":
-                        TagValueBlock vb1 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagValueBlock? vb1 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         vb1.value_type.Text = "4 Byte";
                         vb1.value.Text = _m.ReadInt((address + entry.Key).ToString("X")).ToString(); // (+entry.Key?) lmao, no wonder why it wasn't working
                         parentpanel.Children.Add(vb1);
@@ -339,7 +340,7 @@ namespace Assembly69.Interface.Controls
                         vb1.value.TextChanged += new TextChangedEventHandler(value_TextChanged);
                         break;
                     case "2Byte":
-                        TagValueBlock vb6 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagValueBlock? vb6 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         vb6.value_type.Text = "2 Byte";
                         vb6.value.Text = _m.Read2Byte((address + entry.Key).ToString("X")).ToString();
                         parentpanel.Children.Add(vb6);
@@ -349,7 +350,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "Float":
-                        TagValueBlock vb2 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagValueBlock? vb2 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         vb2.value_type.Text = "Float";
                         vb2.value.Text = _m.ReadFloat((address + entry.Key).ToString("X")).ToString();
                         parentpanel.Children.Add(vb2);
@@ -359,7 +360,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "TagRef":
-                        TagRefBlock tfb1 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagRefBlock? tfb1 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         foreach (string s in _mainWindow.TagGroups.Keys)
                         {
                             tfb1.taggroup.Items.Add(s);
@@ -395,7 +396,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "Pointer":
-                        TagValueBlock vb3 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagValueBlock? vb3 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         vb3.value_type.Text = "Pointer";
                         vb3.value.Text = _m.ReadLong((address + entry.Key).ToString("X")).ToString("X");
                         parentpanel.Children.Add(vb3);
@@ -405,7 +406,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "Tagblock": // need to find some kinda "whoops that tag isnt actually loaded"; keep erroring with the hlmt tag
-                        TagBlock tb1 = new(this) { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagBlock? tb1 = new(this) { HorizontalAlignment = HorizontalAlignment.Left };
                         long newAddress = _m.ReadLong((address + entry.Key).ToString("X"));
                         tb1.tagblock_address.Text = "0x" + newAddress.ToString("X");
 
@@ -454,7 +455,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "String":
-                        TagValueBlock vb4 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagValueBlock? vb4 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         vb4.value_type.Text = "String";
                         vb4.value.Text = _m.ReadString((address + entry.Key).ToString("X")).ToString();
                         parentpanel.Children.Add(vb4);
@@ -464,7 +465,7 @@ namespace Assembly69.Interface.Controls
                         break;
 
                     case "Flags":
-                        TagsFlags vb9 = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagsFlags? vb9 = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         byte flags_value = (byte)_m.ReadByte((address + entry.Key).ToString("X"));
                         parentpanel.Children.Add(vb9);
 
@@ -492,7 +493,7 @@ namespace Assembly69.Interface.Controls
                             continue;
                         
                         var fg = entry.Value as Vehi.FlagGroup;
-                        TagFlagsGroup tfg = new() { HorizontalAlignment = HorizontalAlignment.Left };
+                        TagFlagsGroup? tfg = new() { HorizontalAlignment = HorizontalAlignment.Left };
                         tfg.M = _mainWindow.M;
                         tfg._mainwindow = _mainWindow;
 
@@ -595,10 +596,10 @@ namespace Assembly69.Interface.Controls
                 if (control is TagRefBlock)
                 {
                     var trb = (TagRefBlock) control;
-                    ComboBoxItem cbxi = trb.taggroup.SelectedItem as ComboBoxItem;
+                    ComboBoxItem? cbxi = trb.taggroup.SelectedItem as ComboBoxItem;
                     if (cbxi == null) continue;
 
-                    string str = cbxi.Content as string;
+                    string? str = cbxi.Content as string;
                     if (str != null && str.Contains(filterText, StringComparison.OrdinalIgnoreCase))
                     {
                         control.Visibility = Visibility.Visible;

--- a/Interface/Controls/TagFlagsGroup.xaml.cs
+++ b/Interface/Controls/TagFlagsGroup.xaml.cs
@@ -20,25 +20,25 @@ namespace Assembly69.Interface.Controls
     /// </summary>
     public partial class TagFlagsGroup : UserControl
     {
-        public MainWindow _mainwindow;
-        public Memory.Mem M;
+        public MainWindow? _mainwindow;
+        public Memory.Mem? M;
         public long startAddress;
-        public int amountOfBytes;
-        public int maxBit;
+        public int? amountOfBytes;
+        public int? maxBit;
 
         public TagFlagsGroup()
         {
             InitializeComponent();
         }
 
-        public void generateBits(long startAddress, int amountOfBytes, int maxBit, Dictionary<int, string> descriptions = null)
+        public void generateBits(long startAddress, int amountOfBytes, int maxBit, Dictionary<int, string>? descriptions = null)
         {
             this.startAddress = startAddress; 
             this.amountOfBytes = amountOfBytes; 
             this.maxBit = maxBit;  
 
             if (maxBit == 0)
-                this.maxBit = maxBit = amountOfBytes * 8;
+                maxBit = maxBit = amountOfBytes * 8;
 
             spBitCollection.Children.Clear();
 
@@ -60,7 +60,7 @@ namespace Assembly69.Interface.Controls
                     if (bitsLeft < 0)
                         continue;
 
-                    CheckBox checkbox = null;
+                    CheckBox? checkbox = null;
 
                     int _byte = @byte, _bit = bit;
 
@@ -85,7 +85,7 @@ namespace Assembly69.Interface.Controls
                 }
             }
 
-            int x = 0;
+            //int x = 0;
         }
 
         private void Checkbox_BitIsChanged(int byteNo, int bit)
@@ -99,8 +99,8 @@ namespace Assembly69.Interface.Controls
                 if (spBitCollection.Children.Count < index)
                     continue;
 
-                var cbx = (CheckBox) spBitCollection.Children[index];
-                output.UpdateBit(x, (bool) cbx.IsChecked);
+                CheckBox? cbx = (CheckBox) spBitCollection.Children[index];
+                output.UpdateBit(x, value: (bool) cbx.IsChecked);
             }
 
             _mainwindow.Addpokechange(targetAddress, "Flags", output.ToString());

--- a/Interface/Controls/TagsFlags.xaml.cs
+++ b/Interface/Controls/TagsFlags.xaml.cs
@@ -20,16 +20,13 @@ namespace Assembly69.Interface.Controls
     /// </summary>
     public partial class TagsFlags : UserControl
     {
-        public TagsFlags()
-        {
-            InitializeComponent();
-        }
+        public TagsFlags() => InitializeComponent();
 
 
         public long address;
-        public MainWindow _mainwindow;
+        public MainWindow? _mainwindow;
 
-        public void calculate_and_report()
+        public void Calculate_and_report()
         {
             if (_mainwindow != null)
             {
@@ -49,7 +46,7 @@ namespace Assembly69.Interface.Controls
 
         private void flag1_Checked(object sender, RoutedEventArgs e)
         {
-            calculate_and_report();
+            Calculate_and_report();
         }
     }
 }

--- a/Interface/Windows/TagRefDropdown.xaml.cs
+++ b/Interface/Windows/TagRefDropdown.xaml.cs
@@ -15,7 +15,7 @@ namespace Assembly69.Interface.Windows
             InitializeComponent();
         }
 
-        public MainWindow MainWindow;
+        public MainWindow? MainWindow;
 
         private void Window_Deactivated(object sender, EventArgs e)
         {

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -204,7 +204,7 @@
 
                             <CheckBox Grid.Column="2" VerticalAlignment="Center" Margin="5,0,0,0"
                                       x:Name="cbxFilterOnlyMapped"
-                                      Checked="cbxFilterOnlyMapped_Changed" Unchecked="cbxFilterOnlyMapped_Changed">
+                                      Checked="cbxFilterOnlyMapped_Changed" Unchecked="cbxFilterOnlyMapped_Changed" IsChecked="True">
                                 <CheckBox.ToolTip>
                                     <TextBlock Foreground="Black">Only show mapped tags</TextBlock>
                                 </CheckBox.ToolTip>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -36,10 +36,10 @@ namespace Assembly69
 
         public Mem M = new();
 
-        public TagRefDropdown? Trd { get; set; } = null; // this is our dropdown box for selecting tag references
-        public Button? TheLastTagrefButtonWePressed { get; set; } = null; // since we did it for the window why not also do it for the button
+        public TagRefDropdown? Trd { get; set; } // this is our dropdown box for selecting tag references
+        public Button? TheLastTagrefButtonWePressed { get; set; } // since we did it for the window why not also do it for the button
 
-        public Dictionary<string, TagEditorControl> TagEditors { get; set; } = new();
+        public Dictionary<string, TagEditorControl>? TagEditors { get; set; } = new();
 
         public MainWindow()
         {
@@ -103,7 +103,7 @@ namespace Assembly69
             }
         }
 
-        public List<TagStruct> TagsList { get; set; }
+        public List<TagStruct> TagsList { get; set; } = new List<TagStruct>();
         public SortedDictionary<string, GroupTagStruct> TagGroups { get; set; } = new();
 
         public struct TagStruct
@@ -266,7 +266,7 @@ namespace Assembly69
 
         public string convert_ID_to_tag_name(string value)
         {
-            InhaledTagnames.TryGetValue(value, out string potentialName);
+            _ = InhaledTagnames.TryGetValue(value, value: out string? potentialName);
 
             return potentialName ??= "ObjectID: " + value;
         }
@@ -299,17 +299,22 @@ namespace Assembly69
                         dockSearch.IsActive = true;
 
                     // Set the tag as the active tab
-                    bool found = false; // used for debugging
                     if (dockSearch.Parent is LayoutDocumentPane ldp)
                     {
                         for (int x = 0; x < ldp.Children.Count; x++)
                         {
-                            var dlp = ldp.Children[x];
+                            LayoutContent dlp = ldp.Children[x];
 
                             if (dlp == dockSearch)
                             {
-                                found = true;
+                                bool? found = true;
                                 ldp.SelectedContentIndex = x;
+                                Console.WriteLine(found);
+                            }
+                            else
+                            {
+                                bool? found = false; // used for debugging
+                                Console.WriteLine(found);
                             }
                         }
                     }
@@ -320,7 +325,7 @@ namespace Assembly69
 
             // Create the tag editor.
             var tagEditor = new TagEditorControl(this);
-            tagEditor.inhale_tag(tagIndex);
+            tagEditor.Inhale_tag(tagIndex);
 
             // Create the layout document for docking.
             LayoutDocument doc = tagEditor.LayoutDocument = new LayoutDocument();
@@ -427,7 +432,7 @@ namespace Assembly69
                         break;
 
                     case "Pointer":
-                        string willThisWork = new System.ComponentModel.Int64Converter().ConvertFromString(value).ToString();
+                        string? willThisWork = new System.ComponentModel.Int64Converter().ConvertFromString(value).ToString();
                         M.WriteMemory(address.ToString("X"), "long", willThisWork); // apparently it does
                         break;
 
@@ -446,7 +451,7 @@ namespace Assembly69
                         string temp = Regex.Replace(value, @"(.{2})", "$1 ");
                         temp = temp.TrimEnd();
                         M.WriteMemory(address.ToString("X"), "bytes", temp);
-                        int w2 = 0;
+                        //int w2 = 0;
 
                         break;
                 }
@@ -527,7 +532,7 @@ namespace Assembly69
         }
 
         // State change
-        private void MainWindowStateChangeRaised(object sender, EventArgs e)
+        private void MainWindowStateChangeRaised(object? sender, EventArgs e)
         {
             if (WindowState == WindowState.Maximized)
             {
@@ -546,13 +551,13 @@ namespace Assembly69
 
 
         // search filter
-        private void Searchbox_TextChanged(object sender, TextChangedEventArgs e)
+        private void Searchbox_TextChanged(object? sender, TextChangedEventArgs? e)
         {
             string[] supportedTags = Halo.TagObjects.Vehi.MappedTags;
             string search = Searchbox.Text;
-            foreach (TreeViewItem tv in TagsTree.Items)
+            foreach (TreeViewItem? tv in TagsTree.Items)
             {
-                var isSupportedTag = supportedTags.Contains(tv.Header.ToString().Split(' ')[0].ToLower());
+                bool isSupportedTag = supportedTags.Contains(tv.Header.ToString().Split(' ')[0].ToLower());
 
                 // Ignore tags that are not implemented
                 if ((bool) cbxFilterOnlyMapped.IsChecked && !isSupportedTag)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Diagnostics;
 
 using Assembly69.Interface.Controls;
 using Assembly69.Interface.Windows;
@@ -49,14 +50,21 @@ namespace Assembly69
             inhale_tagnames();
         }
 
-        public long BaseAddress = -1;
-        public int TagCount = -1;
+        private long BaseAddress = -1;
+        private int TagCount = -1;
 
         // Hook to halo infinite
         private async void BtnHook_Click(object sender, RoutedEventArgs e)
         {
-            hook_text.Text = "Openning process...";
-            M.OpenProcess("HaloInfinite.exe");
+            hook_text.Text = "Openning process..."; 
+            Process[] process = Process.GetProcessesByName("HaloInfinite");
+            int i = process.Length;
+            while (i > 0)
+            {
+                string haloPid = process[i - 1].Id.ToString();
+                _ = M.OpenProcess(Convert.ToInt32(Convert.ToString(haloPid)));
+                i -= 1;
+            }
             //M.OpenProcess(Convert.ToInt32(haloPid.Text));
 
             if (M.pHandle == IntPtr.Zero)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -604,7 +604,10 @@ namespace Assembly69
                 Searchbox_TextChanged(null, null);
                 return;
             }
+            if (TagsTree != null)
+            { 
 
+            
             foreach (TreeViewItem tv in TagsTree.Items)
             {
                 // Ignore tags that are not implemented
@@ -618,6 +621,7 @@ namespace Assembly69
                 else
                 {
                     tv.Visibility = Visibility.Visible;
+                }
                 }
             }
         }

--- a/Themes/TreeViewItemExtensions.cs
+++ b/Themes/TreeViewItemExtensions.cs
@@ -15,7 +15,7 @@ namespace DarkBlendTheme
     {
         public static int GetDepth(this TreeViewItem item)
         {
-            TreeViewItem parent;
+            TreeViewItem? parent;
             while ((parent = GetParent(item)) != null)
             {
                 return GetDepth(parent) + 1;
@@ -23,7 +23,7 @@ namespace DarkBlendTheme
             return 0;
         }
 
-        private static TreeViewItem GetParent(TreeViewItem item)
+        private static TreeViewItem? GetParent(TreeViewItem item)
         {
             var parent = VisualTreeHelper.GetParent(item);
 				


### PR DESCRIPTION
Fixes the following:

1. Program crash with a Win32 exception. Not sure what exactly was causing this, but fixed by searching the process name and "hooking" into it via a PID instead, converted to int32.
2. Fixes many warnings, mostly caused by differences between nullable and non-nullable types.
3. Fixes a crash that happens when you hook and load the tags before the game has fully loaded and opening one of those tags. Will now no longer crash and will simply not populate the tag editor window with anything, but loading again closing the tag and reopening it should allow you to edit tags again normally. Necessary if you want to implement an automatic process hooker and tag loader setting.