### PR TITLE
Auto Process Hooking & Hooking Implemented Into Load Button

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -217,7 +217,7 @@
                         <TreeViewItem Header="Hook and load to get started!" />
                         <TreeViewItem Header="reload the tags whenever the map changes" />
 
-                        
+
                     </TreeView>
                     <!-- < #TagsTree -->
 
@@ -235,7 +235,13 @@
 
                         <Button Content="Hook" Grid.Column="0" Click="BtnHook_Click" Padding="4,4,4,4" />
                         <TextBlock x:Name="hook_text" Text="Not hooked" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" />
-
+                        <CheckBox Grid.Column="1" VerticalAlignment="Top" Margin="154,5,10,0"
+                                      x:Name="CbxSearchProcess"
+                                      Checked="CheckBoxProcessCheck" Unchecked="CheckBoxProcessCheck" IsChecked="False">
+                            <CheckBox.ToolTip>
+                                <TextBlock Foreground="Black">Auto Hook</TextBlock>
+                            </CheckBox.ToolTip>
+                        </CheckBox>
                         <Button Content="Load" Grid.Column="2" Click="BtnLoadTags_Click" Padding="4,4,4,4" />
 
                         <controls:ProcessSelector x:Name="processSelector" Grid.Row="1" Grid.ColumnSpan="3" Margin="00,2,0,0" />

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -231,18 +231,15 @@
                             <RowDefinition Height="auto" />
                             <RowDefinition Height="auto" />
                         </Grid.RowDefinitions>
-
-
-                        <Button Content="Hook" Grid.Column="0" Click="BtnHook_Click" Padding="4,4,4,4" />
                         <TextBlock x:Name="hook_text" Text="Not hooked" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" />
-                        <CheckBox Grid.Column="1" VerticalAlignment="Top" Margin="154,5,10,0"
+                        <CheckBox Grid.Column="1" VerticalAlignment="Top" Margin="211,12,5,0"
                                       x:Name="CbxSearchProcess"
                                       Checked="CheckBoxProcessCheck" Unchecked="CheckBoxProcessCheck" IsChecked="False">
                             <CheckBox.ToolTip>
-                                <TextBlock Foreground="Black">Auto Hook</TextBlock>
+                                <TextBlock Foreground="Black">Auto Hook And Load</TextBlock>
                             </CheckBox.ToolTip>
                         </CheckBox>
-                        <Button Content="Load" Grid.Column="2" Click="BtnLoadTags_Click" Padding="4,4,4,4" />
+                        <Button Content="Load" Grid.Column="2" Click="BtnLoadTags_ClickAsync" Padding="4,4,4,4" />
 
                         <controls:ProcessSelector x:Name="processSelector" Grid.Row="1" Grid.ColumnSpan="3" Margin="00,2,0,0" />
                     </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Xml.Serialization;
 using InfiniteRuntimeTagViewer.Halo.TagObjects;
 using System.Windows.Media;
 using System.Timers;
+using System.Threading.Tasks;
 
 namespace InfiniteRuntimeTagViewer
 {
@@ -52,11 +53,133 @@ namespace InfiniteRuntimeTagViewer
 			inhale_tagnames();
         }
 
-		private async void OnTimedEvent(object source, ElapsedEventArgs e)
+		private bool loadedTags = false;
+		private void OnTimedEvent(object source, ElapsedEventArgs e)
 		{
 			System.Diagnostics.Debugger.Log(0, "DBGTIMING", "Hooking game");
-			Dispatcher.Invoke(new Action(async () => {
+			Dispatcher.Invoke(new Action(async () =>
+			{
 				hook_text.Text = "Openning process...";
+				processSelector.hookProcess(M);
+
+				if (M.pHandle == IntPtr.Zero)
+				{
+					// Could not find the process
+					hook_text.Text = "Cant find HaloInfinite.exe";
+					return;
+				}
+
+				// Get the base address
+				BaseAddress = M.ReadLong("HaloInfinite.exe+0x3E952A0");
+				string validtest = M.ReadString(BaseAddress.ToString("X"));
+
+				if (validtest == "tag instances")
+				{
+					hook_text.Text = "Process Hooked: " + M.theProc.Id;
+				}
+				else
+				{
+					hook_text.Text = "Offset failed, scanning...";
+					try
+					{
+						long? aobScan = (await M.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))
+							.First(); // "tag instances"
+
+						// Failed to find base tag address
+						if (aobScan == null || aobScan == 0)
+						{
+							BaseAddress = -1;
+							loadedTags = false;
+							hook_text.Text = "Failed to locate base tag address";
+						}
+						else
+						{
+							BaseAddress = aobScan.Value;
+							hook_text.Text = "Process Hooked: " + M.theProc.Id + " (AOB)";
+						}
+					}
+					catch (Exception)
+					{
+						hook_text.Text = "Cant find HaloInfinite.exe";
+					}
+
+				}
+				if (BaseAddress != -1 && loadedTags == false)
+				{
+					if (TagCount != -1)
+					{
+						TagCount = -1;
+						TagGroups.Clear();
+						TagsList.Clear();
+					}
+
+					TagsTree.Items.Clear();
+
+					TagCount = M.ReadInt((BaseAddress + 0x6C).ToString("X"));
+					long tagsStart = M.ReadLong((BaseAddress + 0x78).ToString("X"));
+
+					// each tag is 52 bytes long // was it 52 or was it 0x52? whatever
+					// 0x0 datnum 4bytes
+					// 0x4 ObjectID 4bytes
+					// 0x8 Tag_group Pointer 8bytes
+					// 0x10 Tag_data Pointer 8bytes
+					// 0x18 Tag_type_desc Pointer 8bytes
+
+					TagsList = new Dictionary<string, TagStruct>();
+					for (int tagIndex = 0; tagIndex < TagCount; tagIndex++)
+					{
+						TagStruct currentTag = new();
+						long tagAddress = tagsStart + (tagIndex * 52);
+
+						byte[] test1 = M.ReadBytes(tagAddress.ToString("X"), 4);
+						currentTag.Datnum = BitConverter.ToString(test1).Replace("-", string.Empty);
+
+						byte[] test = (M.ReadBytes((tagAddress + 4).ToString("X"), 4));
+
+						// = String.Concat(bytes.Where(c => !Char.IsWhiteSpace(c)));
+						currentTag.ObjectId = BitConverter.ToString(test).Replace("-", string.Empty);
+						currentTag.TagGroup = read_tag_group(M.ReadLong((tagAddress + 0x8).ToString("X")));
+						currentTag.TagData = M.ReadLong((tagAddress + 0x10).ToString("X"));
+						currentTag.TagFullName = convert_ID_to_tag_name(currentTag.ObjectId).Trim();
+						currentTag.TagFile = currentTag.TagFullName.Split('\\').Last().Trim();
+
+						// do the tag definitition
+						if (!TagsList.ContainsKey(currentTag.ObjectId))
+						{
+							TagsList.Add(currentTag.ObjectId, currentTag);
+						}
+					}
+
+					Loadtags();
+
+					Searchbox_TextChanged(null, null);
+
+					System.Diagnostics.Debugger.Log(0, "DBGTIMING", "Done loading tags");
+					loadedTags = true;
+				}
+			}));
+		}
+
+		private void CheckBoxProcessCheck(object sender, RoutedEventArgs e)
+		{
+			if (CbxSearchProcess.IsChecked != null && CbxSearchProcess.IsChecked == true)
+			{
+				_t.Enabled = true;
+			}
+		}
+
+		private long BaseAddress = -1;
+        private int TagCount = -1;
+
+        public Dictionary<string, TagStruct> TagsList { get; set; } = new (); // and now we can convert it back because we just sort it elsewhere
+        public SortedDictionary<string, GroupTagStruct> TagGroups { get; set; } = new();
+
+		
+
+        // load tags from Mem
+        private async void BtnLoadTags_ClickAsync(object sender, RoutedEventArgs e)
+        {
+			hook_text.Text = "Openning process...";
 			processSelector.hookProcess(M);
 
 			if (M.pHandle == IntPtr.Zero)
@@ -77,97 +200,25 @@ namespace InfiniteRuntimeTagViewer
 			else
 			{
 				hook_text.Text = "Offset failed, scanning...";
-					try
-					{
-						long? aobScan = (await M.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))
-							.First(); // "tag instances"
 
-						// Failed to find base tag address
-						if (aobScan == null || aobScan == 0)
-						{
-							BaseAddress = -1;
-							hook_text.Text = "Failed to locate base tag address";
-						}
-						else
-						{
-							BaseAddress = aobScan.Value;
-							hook_text.Text = "Process Hooked: " + M.theProc.Id + " (AOB)";
-						}
-					}
-					catch (Exception ex)
-					{
-						hook_text.Text = "Cant find HaloInfinite.exe";
-					}
-			}
-			}));
-		}
-
-		private void CheckBoxProcessCheck(object sender, RoutedEventArgs e)
-		{
-			if (CbxSearchProcess.IsChecked != null)
-			{
-				_t.Enabled = (bool) CbxSearchProcess.IsChecked;
-			}
-		}
-
-		private long BaseAddress = -1;
-        private int TagCount = -1;
-
-        // Hook to halo infinite
-        private async void BtnHook_Click(object sender, RoutedEventArgs e)
-        {
-			System.Diagnostics.Debugger.Log(0, "DBGTIMING", "Hooking game");
-
-            hook_text.Text = "Openning process...";
-            processSelector.hookProcess(M);
-
-            if (M.pHandle == IntPtr.Zero)
-            {
-                // Could not find the process
-                hook_text.Text = "Cant find HaloInfinite.exe";
-                return;
-            }
-
-            // Get the base address
-            BaseAddress = M.ReadLong("HaloInfinite.exe+0x3E952A0");
-            string validtest = M.ReadString(BaseAddress.ToString("X"));
-
-            if (validtest == "tag instances")
-            {
-                hook_text.Text = "Process Hooked: " + M.theProc.Id;
-            }
-            else
-            {
-                hook_text.Text = "Offset failed, scanning...";
-
-                long? aobScan = (await M.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))
+				long? aobScan = (await M.AoBScan("74 61 67 20 69 6E 73 74 61 6E 63 65 73", true))
 					.First(); // "tag instances"
 
-                // Failed to find base tag address
-                if (aobScan == null || aobScan == 0)
-                {
-                    BaseAddress = -1;
-                    hook_text.Text = "Failed to locate base tag address";
-                }
-                else
-                {
-                    BaseAddress = aobScan.Value;
+				// Failed to find base tag address
+				if (aobScan == null || aobScan == 0)
+				{
+					BaseAddress = -1;
+					hook_text.Text = "Failed to locate base tag address";
+				}
+				else
+				{
+					BaseAddress = aobScan.Value;
 					hook_text.Text = "Process Hooked: " + M.theProc.Id + " (AOB)";
 				}
-            }
-        }
+			}
 
-        public Dictionary<string, TagStruct> TagsList { get; set; } = new (); // and now we can convert it back because we just sort it elsewhere
-        public SortedDictionary<string, GroupTagStruct> TagGroups { get; set; } = new();
 
-		
-
-        // load tags from Mem
-        private void BtnLoadTags_Click(object sender, RoutedEventArgs e)
-        {
-			System.Diagnostics.Debugger.Log(0, "DBGTIMING", "Loading tags");
-
-			if (TagCount != -1)
+			if (TagCount != -1 && BaseAddress != -1)
             {
                 TagCount = -1;
                 TagGroups.Clear();
@@ -206,14 +257,14 @@ namespace InfiniteRuntimeTagViewer
 
 				// do the tag definitition
 				if (!TagsList.ContainsKey(currentTag.ObjectId))
-				TagsList.Add(currentTag.ObjectId, currentTag); // WHAT DO YOU MEAN ITS ALREADY ADDED. HOW IS THERE A DUPLICATE TAG
-            }
+				{
+					TagsList.Add(currentTag.ObjectId, currentTag); // WHAT DO YOU MEAN ITS ALREADY ADDED. HOW IS THERE A DUPLICATE TAG
+				}
+			}
 
             Loadtags();
 
             Searchbox_TextChanged(null, null);
-
-			System.Diagnostics.Debugger.Log(0, "DBGTIMING", "Done loading tags");
 		}
 
 		public string read_tag_group(long tagGroupAddress)
@@ -230,16 +281,18 @@ namespace InfiniteRuntimeTagViewer
 
                 long testAddress = M.ReadLong((tagGroupAddress + 0x48).ToString("X"));
                 if (testAddress != 0)
-                    currentGroup.TagExtraName = M.ReadString((testAddress).ToString("X"));
+				{
+					currentGroup.TagExtraName = M.ReadString((testAddress).ToString("X"));
+				}
 
-                // Doing the UI here so we dont have to literally reconstruct the elements elsewhere // lol // xd how'd that work out for you
-                //TreeViewItem sortheader = new TreeViewItem();
-                //sortheader.Header = ReverseString(current_group.tag_group_name.Substring(0, 4)) + " (" + current_group.tag_group_desc + ")";
-                //sortheader.ToolTip = current_group.tag_group_definitition;
-                //TagsTree.Items.Add(sortheader);
-                //current_group.tag_category = sortheader;
+				// Doing the UI here so we dont have to literally reconstruct the elements elsewhere // lol // xd how'd that work out for you
+				//TreeViewItem sortheader = new TreeViewItem();
+				//sortheader.Header = ReverseString(current_group.tag_group_name.Substring(0, 4)) + " (" + current_group.tag_group_desc + ")";
+				//sortheader.ToolTip = current_group.tag_group_definitition;
+				//TagsTree.Items.Add(sortheader);
+				//current_group.tag_category = sortheader;
 
-                TagGroups.Add(key, currentGroup);
+				TagGroups.Add(key, currentGroup);
             }
 
             return key;


### PR DESCRIPTION
Added a checkbox that makes the program try to hook into the process and load the tags afterward every 2 seconds. Hooking and loading now happens at the same time, without the need to have a separate button for each one. Pressing the load button will try to hook the process, if it has not already, then load the tags if it successfully hooked the process.

Note: Tags are only automatically loaded with the checkbox ONCE (until the checkbox is unchecked and rechecked or HaloInfinite is closed and reopened. Any more and the program would constantly freeze.