### PR TITLE
Reduce UI Freezing Duration While Loading Tags

### DIFF
--- a/Interface/Windows/PointerDialog.xaml
+++ b/Interface/Windows/PointerDialog.xaml
@@ -128,7 +128,7 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Label Grid.Column="0" Grid.Row="0">Pointer to tags...</Label>
-                <TextBox Foreground="White" x:Name="pointer" Grid.Column="1" Grid.Row="0" />
+                <TextBox Foreground="White" x:Name="pointer" Grid.Column="1" Grid.Row="0" CaretBrush="White" />
 
                 <!-- Accept or Cancel -->
                 <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">

--- a/Interface/Windows/PointerDialog.xaml.cs
+++ b/Interface/Windows/PointerDialog.xaml.cs
@@ -21,9 +21,11 @@ namespace InfiniteRuntimeTagViewer.Interface.Windows
 	/// </summary>
 	public partial class PointerDialog : Window
 	{
+
 		public PointerDialog()
 		{
 			InitializeComponent();
+			pointer.Text = Settings.Default.ProcAsyncBaseAddr;
 		}
 
 		private readonly MainWindow mw = new();


### PR DESCRIPTION
- Reduce freezing time while loading the tags.
- Show current pointer value in the pointer selection dialog box on initial open.


Note: UI Virtualization is still needed to make the UI not completely freeze while loading tags.