### PR TITLE
New options

### DIFF
--- a/Interface/Controls/TagEditorControl.xaml.cs
+++ b/Interface/Controls/TagEditorControl.xaml.cs
@@ -60,65 +60,65 @@ namespace InfiniteRuntimeTagViewer.Interface.Controls
 
 		public void Inhale_tag(string tagID) // i love dictionaries
 		{
-			TagStruct loadingTag = _mainWindow.TagsList[tagID];
-			Tagname_text.Text = _mainWindow.convert_ID_to_tag_name(loadingTag.ObjectId);
-			tagID_text.Text = "ID: " + loadingTag.ObjectId;
-			tagdatnum_text.Text = "Datnum: " + loadingTag.Datnum;
-			tagdata_text.Text = "Tag data address: 0x" + loadingTag.TagData.ToString("X");
+				TagStruct loadingTag = _mainWindow.TagsList[tagID];
+				Tagname_text.Text = _mainWindow.convert_ID_to_tag_name(loadingTag.ObjectId);
+				tagID_text.Text = "ID: " + loadingTag.ObjectId;
+				tagdatnum_text.Text = "Datnum: " + loadingTag.Datnum;
+				tagdata_text.Text = "Tag data address: 0x" + loadingTag.TagData.ToString("X");
 
-			tagfilter_text.Text = "";
+				tagfilter_text.Text = "";
 
-			tagview_panels.Children.Clear();
+				tagview_panels.Children.Clear();
 
-			// OK, now we do a proper check to see if this tag is loaded, finally looked into this
+				// OK, now we do a proper check to see if this tag is loaded, finally looked into this
 
-			try // never done this before and i hope im doing it terribly wrong
-			{
-				// pointer check
-				TagValueBlock p_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
-				p_block.value_type.Text = "Pointer check";
-				p_block.value.Text = _m.ReadLong((loadingTag.TagData).ToString("X")).ToString("X");
-				tagview_panels.Children.Add(p_block);
-
-				// ID check
-				TagValueBlock id_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
-				id_block.value_type.Text = "ID check";
-				string checked_ID = BitConverter.ToString(_m.ReadBytes((loadingTag.TagData + 8).ToString("X"), 4)).Replace("-", string.Empty);
-				id_block.value.Text = checked_ID;
-				tagview_panels.Children.Add(id_block);
-
-				// Datnum check
-				TagValueBlock dat_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
-				dat_block.value_type.Text = "Datnum check";
-				string checked_datnum = BitConverter.ToString(_m.ReadBytes((loadingTag.TagData + 12).ToString("X"), 4)).Replace("-", string.Empty);
-				dat_block.value.Text = checked_datnum;
-				tagview_panels.Children.Add(dat_block);
-
-				if (checked_ID != loadingTag.ObjectId || checked_datnum != loadingTag.Datnum)
+				try // never done this before and i hope im doing it terribly wrong
 				{
-					TextBox tb1 = new TextBox { Text = "Datnum/ID mismatch; Tag appears to be unloaded, meaning it may not be active on the map, else try reloading the tags" };
-					tagview_panels.Children.Add(tb1);
-					return;
-				}
+					// pointer check
+					TagValueBlock p_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
+					p_block.value_type.Text = "Pointer check";
+					p_block.value.Text = _m.ReadLong((loadingTag.TagData).ToString("X")).ToString("X");
+					tagview_panels.Children.Add(p_block);
 
-				//if (TagLayouts.Tags.ContainsKey(loadingTag.TagGroup))
-				//{
+					// ID check
+					TagValueBlock id_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
+					id_block.value_type.Text = "ID check";
+					string checked_ID = BitConverter.ToString(_m.ReadBytes((loadingTag.TagData + 8).ToString("X"), 4)).Replace("-", string.Empty);
+					id_block.value.Text = checked_ID;
+					tagview_panels.Children.Add(id_block);
+
+					// Datnum check
+					TagValueBlock dat_block = new() { HorizontalAlignment = HorizontalAlignment.Left };
+					dat_block.value_type.Text = "Datnum check";
+					string checked_datnum = BitConverter.ToString(_m.ReadBytes((loadingTag.TagData + 12).ToString("X"), 4)).Replace("-", string.Empty);
+					dat_block.value.Text = checked_datnum;
+					tagview_panels.Children.Add(dat_block);
+
+					if (checked_ID != loadingTag.ObjectId || checked_datnum != loadingTag.Datnum)
+					{
+						TextBox tb1 = new TextBox { Text = "Datnum/ID mismatch; Tag appears to be unloaded, meaning it may not be active on the map, else try reloading the tags" };
+						tagview_panels.Children.Add(tb1);
+						return;
+					}
+
+					//if (TagLayouts.Tags.ContainsKey(loadingTag.TagGroup))
+					//{
 					Dictionary<long, TagLayouts.C> tags = TagLayouts.Tags(loadingTag.TagGroup);
-					readTagsAndCreateControls(loadingTag, 0, tags, loadingTag.TagData, tagview_panels, tagID+":");
-				//}
-				//else
-				//{
-				//	TextBox tb = new TextBox { Text = "This tag isn't mapped out ):" };
-				//	tagview_panels.Children.Add(tb);
-				//}
-			}
+					readTagsAndCreateControls(loadingTag, 0, tags, loadingTag.TagData, tagview_panels, tagID + ":");
+					//}
+					//else
+					//{
+					//	TextBox tb = new TextBox { Text = "This tag isn't mapped out ):" };
+					//	tagview_panels.Children.Add(tb);
+					//}
+				}
 			catch
 			{
 				TextBox tb = new TextBox { Text = "ran into an oopsie woopsie, this tag is probably broken/unloaded right now" };
 				tagview_panels.Children.Add(tb);
 			}
 
-
+			
 		}
 
 		// hmm we need a system that reads the pointer and adds it
@@ -1471,19 +1471,11 @@ namespace InfiniteRuntimeTagViewer.Interface.Controls
 						tfob2.f_name.Text = entry.Value.N;
 
 						break;
-
+					
 				}
 
 				prevEntry = entry;
 			}
-		}
-
-		public void fat_chunk_of_code_from_above(long thingo_address, FunctionBlock fb )
-		{
-			// address + entry.Key
-
-
-
 		}
 
 		public static string SUSSY_BALLS(string input, long add_to)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -182,6 +182,24 @@
                                     <TextBlock Foreground="Black">Check for updates on startup.</TextBlock>
                                 </MenuItem.ToolTip>
                             </MenuItem>
+                            <!--Menu item to close dock layout tabs automatically when reloading the tags-->
+                            <MenuItem x:Name="CbxCloseTabs" Header="Close Tabs Automatically" IsCheckable="True" IsChecked="False" Checked="UpdateOptionsFromSettings" Unchecked="UpdateOptionsFromSettings" >
+                                <MenuItem.ToolTip>
+                                    <TextBlock Foreground="Black">Close tag editor tabs automatically when reloading tags.</TextBlock>
+                                </MenuItem.ToolTip>
+                            </MenuItem>
+                            <!--ShowDatanum-->
+                            <MenuItem x:Name="CbxShowDatanum" Header="Show Datanum" IsCheckable="True" IsChecked="False" Checked="UpdateOptionsFromSettings" Unchecked="UpdateOptionsFromSettings" >
+                                <MenuItem.ToolTip>
+                                    <TextBlock Foreground="Black">Show datanum in tag names.</TextBlock>
+                                </MenuItem.ToolTip>
+                            </MenuItem>
+                            <!--ShowTagname precursor WIP-->
+                            <!--<MenuItem x:Name="CbxShowPrecursor" Header="Show Precursor" IsCheckable="True" IsChecked="False" Checked="UpdateOptionsFromSettings" Unchecked="UpdateOptionsFromSettings" >
+                                <MenuItem.ToolTip>
+                                    <TextBlock Foreground="Black">Show precursor in tag names.</TextBlock>
+                                </MenuItem.ToolTip>
+                            </MenuItem>-->
                         </MenuItem>
                         <MenuItem Header="Tools" WindowChrome.IsHitTestVisibleInChrome="True" FontFamily="Segoe UI Light" Height="28">
                             <MenuItem x:Name="TeleportMenuButton" Header="Teleport Menu" Click="OpenTeleportMenu"/>
@@ -232,8 +250,7 @@
 
                 <GridSplitter Grid.Column="2"
                     HorizontalAlignment="Stretch"
-                    Background="#555"
-                    ShowsPreview="true" />
+                    Background="#555" />
 
                 <!-- Tags Grid -->
                 <Grid Grid.Column="3" Background="#252526">
@@ -276,13 +293,13 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="50" />
                                 <ColumnDefinition Width="80" />
-                                <ColumnDefinition Width="110" />
-                                <ColumnDefinition Width="110" />
-                                <ColumnDefinition Width="75" />
+                                <ColumnDefinition Width="100*" />
+                                <ColumnDefinition Width="110*" />
+                                <ColumnDefinition Width="75*" />
                                 <ColumnDefinition />
-                                <ColumnDefinition Width="150" />
-                                <ColumnDefinition Width="125" />
-                                <ColumnDefinition Width="125" />
+                                <ColumnDefinition Width="125*" />
+                                <ColumnDefinition Width="125*" />
+                                <ColumnDefinition Width="125*" />
                             </Grid.ColumnDefinitions>
 
                             <Button     Content="Poke All" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="BtnPokeChanges_Click" Padding="4,4,4,4" />

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -154,5 +154,41 @@ namespace InfiniteRuntimeTagViewer.Properties {
                 this["Updater"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CloseTabsAuto {
+            get {
+                return ((bool)(this["CloseTabsAuto"]));
+            }
+            set {
+                this["CloseTabsAuto"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowDatanum {
+            get {
+                return ((bool)(this["ShowDatanum"]));
+            }
+            set {
+                this["ShowDatanum"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowPrecursor {
+            get {
+                return ((bool)(this["ShowPrecursor"]));
+            }
+            set {
+                this["ShowPrecursor"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -35,5 +35,14 @@
     <Setting Name="Updater" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CloseTabsAuto" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ShowDatanum" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ShowPrecursor" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
- Can now optionally close all tag editor windows when reloading the tags. Useful if changing regions/maps where the old memory is no longer valid.
- Optionally hide the datanum before the tag name (usually the hex address before the tag is shown)
- Fix tags sometimes failing to load due to thread access
- Animate window in real time when using the divider